### PR TITLE
Handle syntax highlighting for quotes that surround the query attribute.

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,11 @@
               language: "html",
             }).value;
 
+            const quote = '<span class="hljs-string">&quot;</span>';
             const codeElement = document.createElement("code");
             codeElement.innerHTML = highlightedElement.replace(
               `<span class="hljs-attr">${placeholder}</span>`,
-              `<span class="hljs-attr">query</span>=&quot;${highlightedQuery}&quot;`
+              `<span class="hljs-attr">query</span>=${quote}${highlightedQuery}${quote}`
             );
             previousSibling.appendChild(codeElement);
             previousSibling.removeAttribute("class");


### PR DESCRIPTION
This fixes issue #4.

__Preview__:
![image](https://github.com/user-attachments/assets/b0ba92b6-593f-4c70-b5a4-7f339bae92f1)